### PR TITLE
Convert into and download GPKG from new Tab in Analysis, fixed bugs

### DIFF
--- a/global.R
+++ b/global.R
@@ -8,6 +8,8 @@ library(glue)
 library(countrycode)
 library(stringi)
 library(shinycssloaders)
+library(sf)
+library(maps)
 
 options(spinner.color="#0275D8", spinner.color.background="#FF000000", spinner.size=5)
 

--- a/ui.R
+++ b/ui.R
@@ -170,13 +170,32 @@ tabPanel("Analysis",
          fluidRow(
            column(3,
                   tags$div(class = "sidenav",
-                           tags$div(class = "sidebar", 
-                                    fileInput("uploaded_csv", "Choose CSV File",
-                                              multiple = FALSE,
-                                              accept = c("text/csv",
-                                                         "text/comma-separated-values,text/plain",
-                                                         ".csv"))
-                                    ),
+                           tags$div(class = "sidebar",
+                                    tabsetPanel(type = "tabs",
+                                                tabPanel("CSV",
+                                                         fileInput("uploaded_csv", "Choose CSV File",
+                                                                   multiple = FALSE,
+                                                                   accept = c("text/csv",
+                                                                              "text/comma-separated-values,text/plain",
+                                                                              ".csv"))
+                                    ),tabPanel("GPKG",
+                                               fileInput("uploaded_gpkg", "Choose GPKG File",
+                                                         multiple = FALSE,
+                                                         accept = c("gpkg")),
+                                               "Or use the current data",
+                                               disabled(actionButton(
+                                                 inputId = "convert_to_spatial_button",
+                                                 label = "Convert"
+                                               )),
+                                               disabled(
+                                                 downloadButton(
+                                                   outputId = "download_gpkg_button",
+                                                   label = "Download .gpkg"
+                                                 )
+                                               )
+                                               
+                                    )
+                                    )),
                            
                            tags$div(class = "sidebar",
                                     "Available analyses",


### PR DESCRIPTION
Uploaded csv or queried data can now be converted into spatial file (geopackage) with the Convert button, and download via "Download .gpkg" button. Both buttons are in the GPKG tab, under the Analysis tab. Summarize now works even when no grouping is chosen.