### PR TITLE
Data plotting, plot customization, seamless "convert to spatial"/"upl…

### DIFF
--- a/global.R
+++ b/global.R
@@ -9,6 +9,8 @@ library(countrycode)
 library(stringi)
 library(sf)
 library(maps)
+library(ggplot2)
+library(viridis)
 
 options(shiny.maxRequestSize = 20*1024*1024^2)
 
@@ -109,3 +111,9 @@ month_year_vector <- c("month","year")
 available_summaries_10th <- append(column_10th,month_year_vector, after = 1)
 
 available_summaries_100th <- append(column_100th,month_year_vector, after = 1)
+
+sf_column_100th <- column_100th[! column_100th %in% c("lat_bin", "lon_bin")] %>%
+                      append("geom")
+  
+sf_column_10th <- column_10th[! column_10th %in% c("lat_bin", "lon_bin")] %>%
+  append("geom")

--- a/ui.R
+++ b/ui.R
@@ -116,22 +116,21 @@ ui <- fluidPage(
                              actionButton(
                                inputId = "filter_button",
                                label = "Filter"
-                             )
-                    ),
-                    
-                    tags$div(class = "sidebar",
-                             "SQL Query:",
-                             textOutput(
-                               outputId = "sql_query"
-                             )),
-                    tags$div(class = "sidebar",
+                             ),
                              disabled(
                                downloadButton(
                                  outputId = "download_button",
                                  label = "Download"
                                )
                              )
-                    )
+                    ),
+                    
+                    tags$div(class = "sidebar",
+                             "SQL Query:",
+                             tags$code(textOutput(
+                               outputId = "sql_query"
+                             )))
+                    
            )
     ),
     
@@ -156,13 +155,11 @@ tabPanel("Analysis",
                                                 tabPanel("CSV",
                                                          fileInput("uploaded_csv", "Choose CSV File",
                                                                    multiple = FALSE,
-                                                                   accept = c("csv",
-                                                                              "comma-separated-values",
-                                                                              ".csv"))
+                                                                   accept = ".csv")
                                     ),tabPanel("GPKG",
                                                fileInput("uploaded_gpkg", "Choose GPKG File",
                                                          multiple = FALSE,
-                                                         accept = c("gpkg")),
+                                                         accept = ".gpkg"),
                                                "Or use the current data",
                                                disabled(actionButton(
                                                  inputId = "convert_to_spatial_button",
@@ -180,6 +177,8 @@ tabPanel("Analysis",
                            
                            tags$div(class = "sidebar",
                                     "Available analyses",
+                                    tabsetPanel(type = "tabs",
+                                                tabPanel("Descriptive",
                                     prettyCheckboxGroup(
                                       inputId = "summaries",
                                       label = "Summarize by",
@@ -187,33 +186,89 @@ tabPanel("Analysis",
                                       shape = "curve",
                                       animation = "pulse"
                                       ),
+                                    disabled(
                                     actionButton(
                                       inputId = "summarize_button",
                                       label = "Summarize"
-                                    )
-                                    ),
-                           
-                           tags$div(class = "sidebar",
+                                    )),
                                     disabled(
                                       downloadButton(
                                         outputId = "download_analyses_button",
                                         label = "Download"
                                       )
                                     )
+                                    ),
+                                    
+                                    tabPanel("Spatial",
+                                             prettyCheckboxGroup(
+                                               inputId = "spatial_analyses",
+                                               label = "Visualization options",
+                                               choices = NULL,
+                                               shape = "curve",
+                                               animation = "pulse"
+                                             ),
+                                             disabled(
+                                             actionButton(
+                                               inputId = "visualize_button",
+                                               label = "Visualize"
+                                             ))
+                                           
+                                             )
+                                    
+                                    
+                                    )
+                           
+                           
                            )
-                           )
-                  ),
+                  )),
            
            column(9,
-                  tags$div(class = "queried_table", 
+                  tags$div(class = "queried_table",
+                           id = "preview-table",
                            tableOutput("uploaded_csv_viz")
                            ),
-                  tags$div(class = "queried_table", 
+                  
+                  tags$div(class = "queried_table",
+                           id = "summary-table",
                            dataTableOutput("summary_preview")
+                  ),
+                  
+                  hidden(tags$div(class = "sidebar",
+                           id = "map",
+                           fluidRow(
+                             column(9,
+                           plotOutput("viz_map")
+                           ),
+                           column(3,
+                                  selectInput(
+                                    inputId = "mapped_column",
+                                    label = "Map by",
+                                    choices = NULL
+                                  ),
+                                  
+                                  numericInput(
+                                    inputId = "map_rez",
+                                    label = "Map resolution",
+                                    value = NULL
+                                  ),
+                                  
+                                  actionButton(
+                                    inputId = "re_visualize_button",
+                                    label = "Re-Visualize"
+                                  ),
+                                  
+                                  downloadButton(
+                                    outputId = "download_map_button",
+                                    label = "Download"
+                                  )
+                                  
+                                  
+                                  
+                                  )
                   )
-           )
+           ))
          )
-)
+))
 
 ),
 

--- a/www/style.css
+++ b/www/style.css
@@ -80,14 +80,28 @@ div.right_sidebar {
 
 }
 
-.sidebar .btn {
-
+.sidebar .btn.action-button{
+	
+	margin-top: 3px;
+	margin-bottom: 3px;
     font-weight: bold;
     font-size: large;
     width: 80%;
     border-radius: 5px;
 
 }
+
+.sidebar .btn.shiny-download-link{
+	
+	margin-top: 3px;
+	margin-bottom: 3px;
+    font-weight: bold;
+    font-size: large;
+    width: 80%;
+    border-radius: 5px;
+
+}
+
 
 .sidebar .btn.btn-file{
 
@@ -199,9 +213,10 @@ form.well {
 
 }
 
-table.dataTable thead > tr > th {
+table thead > tr > th {
     
     padding-left: 0px;
     padding-right: 0px;
+	text-align: center !important;
 
 }


### PR DESCRIPTION
…oad spatial" switch

The user can now seamlessly switch from spatial data converted from csv/query to spatial data uploaded as .gpkg.

The spatial data can now be plotted with a viridis continuous scale, with customizable resolution, with the user deciding which column should define the fill of the plotted cells.

CCS has been tweaked to include tables and buttons in general, rather than just datatables and action buttons, respectively.