### PR TITLE
Prevent plot of empty data and too many summaries, see comment

### DIFF
--- a/global.R
+++ b/global.R
@@ -18,6 +18,9 @@ project <- "global-fishing-watch"
 dataset <- "global_footprint_of_fisheries"
 billing <- "fish-r-man" # your billing account name
 
+bq_auth(email = "user-359@fish-r-man.iam.gserviceaccount.com", 
+        path = "www/appDir/Fish-R-Man-4a4612e29f94.json")
+
 BQ_connection <-  dbConnect(bigquery(), 
                             project = project,
                             dataset = dataset, 

--- a/server.R
+++ b/server.R
@@ -374,6 +374,8 @@ server <- function(input,output,session) {
     
     choice <- input$summaries
     
+    if (length(choice) < 8){
+    
     df <- my_data()
     
     if (!is.null(choice)){
@@ -460,9 +462,13 @@ server <- function(input,output,session) {
       }
       )
     
-    enable(id = "download_analyses_button")
+    enable(id = "download_analyses_button") 
     
-    removeModal()
+    removeModal()} else {
+      showModal(
+      modalDialog(
+        "Maximum 7 fields")
+    )}
    
   })
   
@@ -532,7 +538,7 @@ server <- function(input,output,session) {
                                "lat_bin")
                     )
     
-    removeModal()} else if (which_sf_event$gpkg){
+    } else if (which_sf_event$gpkg){
       
       showModal(
         modalDialog(
@@ -553,18 +559,18 @@ server <- function(input,output,session) {
         
         sdf <- NULL
         
-      }
-      
-      removeModal()
-      
-    }
+      }}
     
-    if (!is.null(sdf)) {
+    
+    
+    if ((!is.null(sdf)) && (length(sdf$geom) > 0)) {
       
       enable(id = "download_gpkg_button")
       enable(id = "visualize_button")
       
-      }
+    }
+    
+    removeModal()
     
     return(sdf)
   })

--- a/ui.R
+++ b/ui.R
@@ -181,7 +181,7 @@ tabPanel("Analysis",
                                                 tabPanel("Descriptive",
                                     prettyCheckboxGroup(
                                       inputId = "summaries",
-                                      label = "Summarize by",
+                                      label = "Summarize by (max 7)",
                                       choices = NULL,
                                       shape = "curve",
                                       animation = "pulse"
@@ -275,10 +275,9 @@ tabPanel("Analysis",
 fluidRow(
   column(12,
          tags$div(class = "footer",
-                  column(2),
-                  
-                  column(3,
-                         tags$a(
+                  column(2,
+                         tags$a(target="_blank",
+                                rel = "noreferrer noopener",
                            img(
                              src = "img/fishrman_banner.png",
                              height = 'auto',
@@ -287,18 +286,41 @@ fluidRow(
                            href="https://github.com/Shyentist/fish-r-man"
                            )),
                   
-                  column(2),
+                  column(5,
+                         tags$p("References"),
+                         "Software by 'Buonomo Pasquale. [2021].",
+                         tags$a("https://github.com/Shyentist/fish-r-man'",
+                                target="_blank",
+                                rel = "noreferrer noopener",
+                                href = "https://github.com/Shyentist/fish-r-man",
+                                style = "color:#000000"),
+                         tags$br(),
+                         "Data by 'Global Fishing Watch. [2021].",
+                         tags$a("www.globalfishingwatch.org'",
+                                target="_blank",
+                                rel = "noreferrer noopener",
+                                href = "https://globalfishingwatch.org/",
+                                style = "color:#000000")),
                   
                   column(3,
-                         tags$a(img(
+                         tags$p("Contacts"),
+                         "E-mail:",
+                         tags$a("pasqualebuonomo@hotmail.it",
+                                target = "_blank",
+                                rel = "noreferrer noopener",
+                                href = "mailto:pasqualebuonomo@hotmail.it",
+                                style = "color:#000000")),
+                  
+                  column(2,
+                         tags$a(target="_blank",
+                                rel = "noreferrer noopener",
+                                img(
                            src = "img/github_logo.png",
                            height = 'auto',
                            width = '100%'
                            ),
                            href="https://github.com/Shyentist/fish-r-man"
-                           )),
-                  
-                  column(2)
+                           ))
                   )
          )
   )

--- a/www/appDir/Fish-R-Man-4a4612e29f94.json
+++ b/www/appDir/Fish-R-Man-4a4612e29f94.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "fish-r-man",
+  "private_key_id": "4a4612e29f94054174cd840605c8c5f99ed9341b",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC58Pl++qcKPAOK\nCwb2+yZlyrc8elv4v1XYKn1yomAZMVnxD2lVwLLPghfJJpQdc/JB++K3xUl1ruqT\nXm40fqXxNJICTdeOXUJO55q1hpXqAfCEzh73zwU3RWzXUDxJdCr5JRlWShKmjALi\nnh4vTtiS7m4t/x2+iSAzwb+atBtsPzyx15S2X4KGB2P9d1McWkBaaAh1LuB7snPP\n2Vn9UgjHOeCLq5ws9KMiftERvdO9w5E3YyVoeLUwOAaZBhApZIPk/QZmhfyCI8gx\npk9g3G9MaQLBChDj3yz5/OmZVPvRByt5PJN5uc9mMosJnYCwLkPEjsW7UarJUi2y\ndal/AZfvAgMBAAECggEAVgvl6ZUk59+N47vmpTTkOAbvdNVK6nngyAAhvYLW5dGo\nxZ1UKZLbLJwPVc68jESzv0VJTbHGpOclNr1kUnapZE3no5lSP1d47/rN5WM6zOfI\n3ixkuFjdGQ7Pp3RB8dwIZvN8Hip5Jwlz7FsvrMTYBGbCJhcBNMNQW6M1f+oJJrXy\n5XB7KTNfEtHjMX8UbFXhUDx0t9FBkw5SGyn4XaDLRO5lDIfoK1tML1rU3e2ax4q8\nPV1ttg/imKuaECB/sLQjc/swWo3L6CzmnS9p8pOaW7uLwmCfx4VwHgbMADsHG7ov\nm+BheXPlCRMw6WcsvD0E1LgwsbeIozcPNsPpNhCigQKBgQDgdh1xlNn75K/luD+x\nwnNt9pD/ajZJcN0+fJC426YQZyfcm9/P5sp4ldBnNTnMdm+xKIb58EFNKnhr/VBS\nqqg3E/bPtyiM+REG52YyALWJJJU14XSLSze7XcphQvejNjjlh/LGtn/jVCTwfe2U\nZs+tN8EFhyD0U7p9Xdd8voibiQKBgQDUEUpwtPLI0sOwwMZnHOdzDkzl5FynwMFP\nt2TTlB9eXL9YDWYyFEytVF726/V4WF2iifM9EKXx19gpQ6GeSWxhAaf5l0Xhm6MB\nfe0hNTl+xngZ34wMuCVR17L0Uss4Z3koyWENTeJZwxxO4AeF4oJNMxVrkyIbUtFn\nsDo7qK/htwKBgQCajRmG7GwPgg4PSYcp2W7rRzvdcf+BH+JmtRRdBHhakPykbPt1\nRj8hOl5twftTKjWLsREHJYOBI34ZNSlKUlFS4z8tFLsqHhC4RTpbsZtNm8/VcrBx\nfNAaBeFkiNzEF4CjorDqXBzApV5t7PdaGFRku5//M2TgdopQ6f2G2hZrqQKBgQCX\npdm2qR7ojxdTQTdfqyKzeylwSBId/8/9Amc+ibC42NgXzlUjQLLoS+ow5uE9cuta\nfQ2MwGf6fmBcebmMKHMxF28YI53cTGCPg45b7eS0jJZ74gkTW2eMlBOrdb1PE2dn\nzEHzsptHlyeaG8glbKnDLOGHcMq2AU4vuKyb1vAXFwKBgDNYXyuw5L+Zf7zG16Iq\nkGY7Hiq4uuWYNv8NUEsAYPDgz43CNT1cMuX9c+eDVlKFsxvLqN11be8nOVfTjgBh\nsntoC1D8qlN46+lYgUWtanE/rf5TPJ96MYcYL7Q+fWLvqTEAjuktVYBB83WzqYkC\n7ddZQMlciIAnNnuNd45G2YPb\n-----END PRIVATE KEY-----\n",
+  "client_email": "user-359@fish-r-man.iam.gserviceaccount.com",
+  "client_id": "117374233103982224160",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/user-359%40fish-r-man.iam.gserviceaccount.com"
+}

--- a/www/style.css
+++ b/www/style.css
@@ -5,7 +5,7 @@ body {
     rgba(0, 0, 0, 0.10)
   ),url("img/boat1.jpg") no-repeat fixed center;
     background-size: 100% 100%;
-    font-size: 0.8vw !important;
+    font-size: 1vw !important;
 
 }
 
@@ -25,6 +25,7 @@ div.tab-content {
     background-color: rgba(255, 255, 255, 0.40);
     border-radius: 15px;
     padding: 0px 12px;
+    margin-bottom: 3px;
 
 }
 
@@ -32,11 +33,20 @@ div.footer {
 
     background-color: rgba(255, 255, 255, 0.40);
     border-radius: 15px;
-    padding: 0px 12px;
-    margin-top: 6px;
+    padding: 6px 6px;
+    margin-top: 3px;
+    margin-bottom: 3px;
     overflow: auto;
+    color: black;
 
 }
+
+div.footer p {
+
+    font-weight: bold;
+
+}
+
 
 ul.nav-tabs {
 
@@ -65,18 +75,6 @@ ul.nav-tabs li.active a {
 
     background-color: rgba(255, 255, 255, 0.40) !important;
     border-color: transparent !important;
-
-}
-
-div.right_sidebar {
-
-    margin: 12px 0px;
-    width: 100%;
-    padding: 12px;
-    background-color: rgba(255, 255, 255, 0.850);
-    border-radius: 15px;
-    text-align:center;
-    position: fixed;
 
 }
 
@@ -213,10 +211,15 @@ form.well {
 
 }
 
-table thead > tr > th {
+table {
     
     padding-left: 0px;
     padding-right: 0px;
 	text-align: center !important;
+    font-size: 0.7vw !important;
 
+}
+
+div#sql_query {
+    font-size: 0.7vw !important;
 }


### PR DESCRIPTION
"Empty" spatial data, meaning dataframes with correct geom and name columns but with 0 rows, do not activate the "Visualize" and "Download .gpkg" buttons.

Maximum 7 "Summarize by" options. More than that is ridiculous both aesthetically and conceptually.

Authentication is now made through a .json file, so that the users can enjoy the app without logging into their own Google Accounts (this will probably change as the app grows).

Hyperlinks now open a new Tab.

Added references and contacts at the bottom of the page.

General restyling to accommodate the changes.