### PR TITLE
New tables from GFW are used, minor debug

### DIFF
--- a/global.R
+++ b/global.R
@@ -15,7 +15,7 @@ library(viridis)
 options(shiny.maxRequestSize = 20*1024*1024^2) #this should take care of the majority of the gpkg sizes
 
 project <- "global-fishing-watch"
-dataset <- "global_footprint_of_fisheries"
+dataset <- "gfw_public_data"
 billing <- "fish-r-man" # your billing account name
 
 bq_auth(email = "fishrman-user@fish-r-man.iam.gserviceaccount.com", #comment these out
@@ -31,9 +31,9 @@ tables_list <- dbListTables(BQ_connection)
 
 list_togglable_ids <- list(
   "date",
-  "lat_bin",
-  "lon_bin",
-  "vessel_hours",
+  "cell_ll_lat",
+  "cell_ll_lon",
+  "hours",
   "fishing_hours",
   "mmsi_present",
   "mmsi",
@@ -42,8 +42,8 @@ list_togglable_ids <- list(
 )
 
 tables_list_ui <- c(
-  "Fishing effort at 100th degree", 
-  "Fishing effort at 10th degree"
+  "Fishing effort at 10th degree", 
+  "Fishing effort at 100th degree"
 )
 
 column_list_fe100_ui <- c(
@@ -62,50 +62,72 @@ column_list_fe10_ui <- c(
   "Latitude", 
   "Longitude",
   "MMSI",
+  "Vessel hours",
   "Fishing hours"
 )
 
 tables_columns_list_ui <- list(
-  column_list_fe100_ui,
-  column_list_fe10_ui
+  column_list_fe10_ui,
+  column_list_fe100_ui
 )
 
 geartype_elements <- c(
+  "dredge_fishing",
   "drifting_longlines",
   "fixed_gear",
+  "pole_and_line",
+  "pots_and_traps",
   "purse_seines",
+  "seiners",
+  "set_gillnets",
+  "set_longlines",
   "squid_jigger",
   "trawlers",
-  "other_fishing"
+  "trollers",
+  "tuna_purse_seines",
+  "other_purse_seines",
+  "other_seines",
+  "fishing"
 )
 
 geartype_names <- c(
+  "Dredge fishing",
   "Drifting longlines",
   "Fixed gear",
+  "Pole and line",
+  "Pots and traps",
   "Purse seines",
+  "Seiners",
+  "Set gillnets",
+  "Set longlines",
   "Squid jigger",
   "Trawlers",
-  "Other fishing gear"
+  "Trollers",
+  "Tuna purse seins",
+  "Other purse seins",
+  "Other seines",
+  "Fishing"
 )
 
 names(geartype_elements) <- geartype_names #to have a cleaner UI, will change with newer version of the tables
 
 column_100th <- c( #the col names are here so I can check against them for validity of uploaded files
   "date",
-  "lat_bin",
-  "lon_bin",
+  "cell_ll_lat",
+  "cell_ll_lon",
   "flag",
   "geartype",
-  "vessel_hours",
+  "hours",
   "fishing_hours",
   "mmsi_present"
   )
 
 column_10th <- c(
   "date",
-  "lat_bin",
-  "lon_bin",
+  "cell_ll_lat",
+  "cell_ll_lon",
   "mmsi",
+  "hours",
   "fishing_hours"
   )
 
@@ -115,8 +137,8 @@ available_summaries_10th <- append(column_10th,month_year_vector, after = 1)
 
 available_summaries_100th <- append(column_100th,month_year_vector, after = 1)
 
-sf_column_100th <- column_100th[! column_100th %in% c("lat_bin", "lon_bin")] %>% #to later check the validity of spatial data uploaded (they must have same colnames as these vectors)
+sf_column_100th <- column_100th[! column_100th %in% c("cell_ll_lat", "cell_ll_lon")] %>% #to later check the validity of spatial data uploaded (they must have same colnames as these vectors)
                       append("geom")
   
-sf_column_10th <- column_10th[! column_10th %in% c("lat_bin", "lon_bin")] %>%
+sf_column_10th <- column_10th[! column_10th %in% c("cell_ll_lat", "cell_ll_lon")] %>%
   append("geom")

--- a/ui.R
+++ b/ui.R
@@ -37,14 +37,14 @@ ui <- fluidPage(
                                           start = "2012-01-01",
                                           end = "2012-01-02",
                                           min = "2012-01-01",
-                                          max = "2017-01-01",
+                                          max = "2021-01-01",
                                           autoclose = FALSE
                                         )
                                       ),
                                       
                                       disabled(
                                         numericRangeInput(
-                                          inputId = "lat_bin",
+                                          inputId = "cell_ll_lat",
                                           label = "Latitude range:",
                                           value = c(-90, 90)
                                         )
@@ -52,7 +52,7 @@ ui <- fluidPage(
                                       
                                       disabled(
                                         numericRangeInput(
-                                          inputId = "lon_bin",
+                                          inputId = "cell_ll_lon",
                                           label = "Longitude range:",
                                           value = c(-180, 180)
                                         )
@@ -60,9 +60,9 @@ ui <- fluidPage(
                                       
                                       disabled(
                                         numericRangeInput(
-                                          inputId = "vessel_hours",
+                                          inputId = "hours",
                                           label = "Vessel hours range:",
-                                          value = c(0, 2000)
+                                          value = c(0, 100000)
                                         )
                                       ),
                                       
@@ -70,7 +70,7 @@ ui <- fluidPage(
                                         numericRangeInput(
                                           inputId = "fishing_hours",
                                           label = "Fishing hours range:",
-                                          value = c(0, 200)
+                                          value = c(0, 100000)
                                         )
                                       ),
                                       
@@ -78,15 +78,7 @@ ui <- fluidPage(
                                         numericRangeInput(
                                           inputId = "mmsi_present",
                                           label = "MMSI present range:",
-                                          value = c(0, 600)
-                                        )
-                                      ),
-                                      
-                                      disabled(
-                                        numericRangeInput(
-                                          inputId = "mmsi",
-                                          label = "MMSI range:",
-                                          value = c(0, 1111111111)
+                                          value = c(0, 10000)
                                         )
                                       )
                              )
@@ -108,6 +100,13 @@ ui <- fluidPage(
                                  label = "Geartype",
                                  choices = geartype_elements,
                                  multiple = TRUE
+                               )
+                             ),
+                             
+                             disabled(
+                               textInput(
+                                 inputId = "mmsi",
+                                 label = "MMSI"
                                )
                              )
                     ),


### PR DESCRIPTION
The new 0.01 degree table has 16 fishing classes (previously 6). The new 0.1 degree table has vessel hours (I think those were missing in the previous version). Both tables have coords named differently, AND properly divided in decimals.

The bug was that, if someone were to input something for Flag and/or Geartype, even after disabling the input box, the inputs were still added to the SQL query. This was just a bother in case the table stayed the same, but using the 10th degree table crashed the app.

Closes #28 