### PR TITLE
Clip data to specific area

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -345,7 +345,7 @@ fluidRow(
                                 style = "color:#000000"),
                          tags$br(),
                          "Data by 'Global Fishing Watch. [2021].",
-                         tags$a("www.globalfishingwatch.org'",
+                         tags$a("https://globalfishingwatch.org/'",
                                 target="_blank",
                                 rel = "noreferrer noopener",
                                 href = "https://globalfishingwatch.org/",

--- a/ui.R
+++ b/ui.R
@@ -187,7 +187,42 @@ tabPanel("Analysis",
                                                )
                                                
                                     )
-                                    )),
+                                    ),
+                                    
+                                    tags$div(class = "sidebar",
+                                             "Area of interest",
+                                             disabled(
+                                             tipify(fileInput("second_uploaded_gpkg", "Choose GPKG File",
+                                              multiple = FALSE,
+                                              accept = ".gpkg"),
+                                                       title = "File must have same CRS as GFW data (EPSG: 4326)", 
+                                              placement = "right", 
+                                              trigger = "hover",
+                                              options = list(container = "body"))),
+                                    
+                                    disabled(
+                                      selectInput(
+                                        inputId = "second_gpkg_layer",
+                                        label = "Layer",
+                                        choices = NULL,
+                                        multiple = FALSE
+                                      )
+                                    ),
+                                    
+                                    disabled(
+                                      tipify(
+                                        prettyCheckbox(
+                                          inputId = "clip",
+                                          label = "Use only data contained in the area?",
+                                          value = FALSE
+                                          ),
+                                        title = "When ticked, analyses are performed only in the area of interest",
+                                        placement = "right",
+                                        trigger = "hover",
+                                        options = list(container = "body"))
+                                    )
+                                    )
+                                    ),
                            
                            tags$div(class = "sidebar",
                                     "Available analyses",

--- a/www/style.css
+++ b/www/style.css
@@ -106,7 +106,8 @@ ul.nav-tabs li.active a {
     font-size: 12px;
     width: 100%;
     padding: 5.5px 12px;
-
+    height: 30px;
+    
 }
 
 .form-control[disabled] {


### PR DESCRIPTION
Data can now be clipped to an area, uploaded as a geopackage file (the layer can be chosen after the upload). Both descriptive and spatial analysis can be performed on such data. Unchecking the related box lets users use the original data instead of the clipped data. Checking the box again performs a new spatial operation for clipping.

This closes #39 