### PR TITLE
Hyperlinked List of ISO Alpha-3 Country Codes

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -97,7 +97,12 @@ ui <- fluidPage(
               disabled(
                 selectInput(
                   inputId = "flag",
-                  label = "Flag",
+                  label = tags$p("Flag", tags$a("(List of ISO Alpha-3 Country Codes)",
+                                               target = "_blank",
+                                               rel = "noreferrer noopener",
+                                               href = "https://www.nationsonline.org/oneworld/country_code_list.htm",
+                                               style = "color:gray; text-decoration: underline; font-size: 0.7vw;"
+                  )),
                   choices = na.omit(codelist$iso3c),
                   multiple = TRUE
                 )


### PR DESCRIPTION
Next to the label for the 'Flag' filter, there is now a hyperlink to a list of ISO Alpha-3 Country Codes, so that users won't have to know them by heart or look them up by themselves. This closes #61 